### PR TITLE
robust 'base' dns-zone setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Further it can contain a `logging` section with:
 - `facility` - Syslog facility (default `local0`)
 - `format` - log format (default `"%(asctime)s %(levelname)s %(name)s: %(message)s"`)
 
+For long DNS records or multi-level subdomains, like `some.service.my-domain.com`, use the key `dns-zone: my-domain.com`.
+
 Example `/etc/iway-certbot-dns-auth.yml`:
 
     account:
@@ -48,10 +50,11 @@ Example `/etc/iway-certbot-dns-auth.yml`:
       password: 'changeme'
     logging:
       syslog: true
+    dns-zone: my-domain.com
 
 ## Usage
 
-Create a new cert for your domain `my-domain.com` with:
+Create a new cert for your domain `my-domain.com` and `service.my-domain.com` with:
 
     certbot \
       certonly \
@@ -62,8 +65,9 @@ Create a new cert for your domain `my-domain.com` with:
       --manual \
       --manual-auth-hook /usr/local/bin/iway-certbot-auth-hook \
       --manual-cleanup-hook /usr/local/bin/iway-certbot-cleanup-hook \
-      --domain my-domain.com
+      --domain my-domain.com --domain service.my-domain.com
 
 Renew cert with:
 
     certbot renew
+

--- a/iway_certbot_dns_auth/api.py
+++ b/iway_certbot_dns_auth/api.py
@@ -20,6 +20,7 @@ class PortalApi(object):
         self.password = password
         self.timeout = (5, 60)
         self.token = None
+        self.session = requests.Session()
         self.login()
 
     def request(
@@ -51,7 +52,11 @@ class PortalApi(object):
             if self.token:
                 kwargs['headers']['authorization'] = 'Bearer %s' % self.token
 
-            func = getattr(requests, method.lower())
+            csrf_token = self.session.cookies.get('csrftoken')
+            if csrf_token:
+                kwargs['headers']['X-CSRFToken'] = csrf_token
+
+            func = getattr(self.session, method.lower())
 
             # logging.getLogger(__package__).debug(
             #    "API request: %s %s %s", method, url, kwargs)

--- a/iway_certbot_dns_auth/dns_challenge.py
+++ b/iway_certbot_dns_auth/dns_challenge.py
@@ -40,6 +40,16 @@ class DnsChallengeHook:
 
         try:
             self.config: Config = Config()
+            # Determine the correct zone name and its IDNA version
+            # The API expects the base zone (e.g., 'my-domain.com'), not the full subdomain.
+            if 'dns-zone' in self.config:
+                self.zone_domain = self.config['dns-zone']
+            else:
+                domain_parts = self.domain.split('.')
+                if len(domain_parts) >= 2:
+                    self.zone_domain = '.'.join(domain_parts[-2:])
+                else:
+                    self.zone_domain = self.domain
         except Exception as exc:
             raise DnsChallengeHookError(
                 'could not read config: %s' % exc) from exc
@@ -51,14 +61,6 @@ class DnsChallengeHook:
         except Exception as exc:
             raise DnsChallengeHookError(
                 'could not connect API: %s' % exc) from exc
-            
-        # Determine the correct zone name and its IDNA version
-        # The API expects the base zone (e.g., 'dasbaum.ch'), not the full subdomain.
-        domain_parts = self.domain.split('.')
-        if len(domain_parts) >= 2:
-            self.zone_domain = '.'.join(domain_parts[-2:])
-        else:
-            self.zone_domain = self.domain
 
         # The IDNA-encoded zone domain (used for API calls)
         self.idna_zone_domain = string_to_idna(self.zone_domain)
@@ -178,3 +180,4 @@ class DnsChallengeHook:
             raise
         except Exception as exc:
             raise DnsChallengeHookError(exc) from exc
+


### PR DESCRIPTION
Hi,
me again. I'm not very well in Python yet, but I'm trying to learn. As a workaround for multi-level subdomains in my DNS zone, I would like to use a fixed key instead of parsing the zone name. Better solution would if I read the dns zone from the API `/api/services/dns/registry` or `/api/services/dns/forward`. But now, this works for me.